### PR TITLE
Added support for TetraMax ATPG SW STIL output (1450.1 Design), added…

### DIFF
--- a/Semi_ATE/STIL/parsers/MacroDefsBlockParser.py
+++ b/Semi_ATE/STIL/parsers/MacroDefsBlockParser.py
@@ -207,10 +207,13 @@ class MacroDefsBlockParser:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)
 
-        label_str = t.value
+        if t.value[-1] == ':':
+            label_str = t.value[0:-1]
+        else:
+            label_str = t.value
         label_strip = label_str.strip()
         label_split = label_strip.split(" ")
-        label = label_split[0]
+        label = label_split[0].strip()
 
         labels = self.macro_labels[self.curr_macro_name]
         if label in labels:
@@ -280,6 +283,8 @@ class MacroDefsBlockParser:
                 for d in tds:
                     indx = 0
                     fstn = DomainUtils.get_full_name(d, sig)
+                    if fstn not in self.sig2wfc:
+                        continue
                     wfc_list = self.sig2wfc[fstn]
                     wfc = vec_data[indx : indx + 1]
                     if wfc == "%":
@@ -443,7 +448,7 @@ class MacroDefsBlockParser:
         if int(t.value) < 1:
             err_msg = "Loop value must be positive!"
             raise Exception(err_msg)
-
+        
         self.start_loop_va = self.macro2va[self.curr_macro_name]
         self.loop_count = int(t.value)
 

--- a/Semi_ATE/STIL/parsers/ProceduresBlockParser.py
+++ b/Semi_ATE/STIL/parsers/ProceduresBlockParser.py
@@ -224,10 +224,13 @@ class ProceduresBlockParser:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)
 
-        label_str = t.value
+        if t.value[-1] == ':':
+            label_str = t.value[0:-1]
+        else:
+            label_str = t.value
         label_strip = label_str.strip()
         label_split = label_strip.split(" ")
-        label = label_split[0]
+        label = label_split[0].strip()
 
         labels = self.proc_labels[self.curr_proc_name]
         if label in labels:
@@ -297,6 +300,8 @@ class ProceduresBlockParser:
                 for d in tds:
                     indx = 0
                     fstn = DomainUtils.get_full_name(d, sig)
+                    if fstn not in self.sig2wfc:
+                        continue
                     wfc_list = self.sig2wfc[fstn]
                     wfc = vec_data[indx : indx + 1]
                     if wfc == "%":

--- a/Semi_ATE/STIL/parsers/SyntaxParserExceptions.py
+++ b/Semi_ATE/STIL/parsers/SyntaxParserExceptions.py
@@ -4,7 +4,6 @@
 
 
 error_map = {
-    "USER_DEFINED_NAME" : "User defined name",
     "base__KEYWORD_ANN": "Ann",
     "b_stil__KEYWORD_STIL": "STIL",
     "b_stil__STIL_VERSION": "version of the STIL = 1.0",
@@ -20,11 +19,10 @@ error_map = {
     "b_header__SOURCE_STRING": "Source information in double quoted string",
     "b_signals__SIGNAL_TYPE": "signal type : In, Out, InOut, Pseudo or Supply",
     "b_timing__WFT_NAME": "Name of the WaveformTable",
-    "b_timing__TIME_EXPR": "Time value in format 'NUMBER UNIT' without whitespace between them,\n\t\t   Where:\n\t\t   - NUMBER can be integer, real or exponential number\n\t\t   - UNIT SI Time unit with engineering prefixes (ns, us, ms, s ...) \n\t\t   Example: '5ns' '1.234ms' '10E-3s' ",
     "b_pattern_burst__PATTERN_BURST_BLOCK_NAME" : "Name of the PatternBurst block",
     "b_pattern_exec__PATTERN_EXEC_BLOCK_NAME" : "Name of the PatternExec block",
     "b_macrodefs__MACRO_NAME" : "Name of the MacroDefs block",
-    
+    "ESCAPED_STRING" : "String in double quotes"    
 }
 
 
@@ -59,7 +57,11 @@ class SyntaxParserExceptions:
             v = error_map.get(err)
             # If the error can not be found in the error map:
             if v == None:
-                if err.endswith("SEMICOLON"):
+                if err.endswith("USER_DEFINED_NAME"):
+                    return_value += "User defined name"
+                elif err.endswith("TIME_EXPR"):
+                    return_value += "Time expression in format 'NUMBER UNIT' without whitespace between them or 'NUMBER MATH_OPERATOR NUMBER UNIT' or 'NUMBER' \n\t\t   Where:\n\t\t   - Mandatory single quotes 'xxx' for the value\n\t\t   - NUMBER can be integer, real or exponential number\n\t\t   - UNIT SI Time/Frequency unit with engineering prefixes (ns, us, ms, s, Hz, MHz ...)\n\t\t   - MATH_OPERATOR can be *,/,+.- \n\t\t   Example: '5ns' '1.234ms' '10E-3s' '1MHz' '2/1MHz' "
+                elif err.endswith("SEMICOLON"):
                     return_value += ";"
                 elif err.find("QUOTE") > -1:
                     return_value += "'"
@@ -125,6 +127,36 @@ class SyntaxParserExceptions:
                     return_value += "Name of the MacroDefs domain"
                 elif err.endswith("KEYWORD_SIGNAL_GROUPS"):
                     return_value += "SignalGroups"
+                elif err.endswith("KEYWORD_IFNEEDED"):
+                    return_value += "IfNeed"
+                elif err.endswith("KEYWORD_BLOCK_SCAN_STRUCTURES"):
+                    return_value += "ScanStructures"
+                elif err.endswith("KEYWORD_BLOCK_ANN"):
+                    return_value += "Ann"
+                elif err.endswith("KEYWORD_BLOCK_USER_KEYWORDS"):
+                    return_value += "UserKeywords"
+                elif err.endswith("KEYWORD_BLOCK_USER_FUNCTIONS"):
+                    return_value += "UserFunctions"
+                elif err.endswith("KEYWORD_BLOCK_PATTERN"):
+                    return_value += "Pattern"
+                elif err.endswith("KEYWORD_BLOCK_SELECTOR"):
+                    return_value += "Selector"
+                elif err.endswith("KEYWORD_BLOCK_PATERN_EXEC"):
+                    return_value += "PatternExec"
+                elif err.endswith("KEYWORD_BLOCK_SPEC"):
+                    return_value += "Spec"
+                elif err.endswith("KEYWORD_BLOCK_SIGNALS"):
+                    return_value += "Signals"
+                elif err.endswith("KEYWORD_BLOCK_HEADER"):
+                    return_value += "Header"
+                elif err.endswith("KEYWORD_BLOCK_PROCEDURES"):
+                    return_value += "Procedures"
+                elif err.endswith("KEYWORD_BLOCK_TIMING"):
+                    return_value += "Timing"
+                elif err.endswith("KEYWORD_BLOCK_PATTERN_BURST"):
+                    return_value += "PatternBurst"
+                elif err.endswith("KEYWORD_BLOCK_MACRO_DEFS"):
+                    return_value += "MacroDefs"
                 elif err.endswith("KEYWORD_PAT_LIST"):
                     return_value += "PatList"
                 elif err.endswith("KEYWORD_CALL"):

--- a/Semi_ATE/STIL/parsers/TimingBlockParser.py
+++ b/Semi_ATE/STIL/parsers/TimingBlockParser.py
@@ -203,7 +203,7 @@ class TimingBlockParser:
                     err_msg = f"Force Waveform event '{t.value}' is used for 'Out' type of signal !"
                     raise Exception(err_msg)
 
-    def b_timing__wfcs_definition(self, t):
+    def b_timing__time_offset(self, t):
         if self.debug:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)

--- a/Semi_ATE/STIL/parsers/WFCUtils.py
+++ b/Semi_ATE/STIL/parsers/WFCUtils.py
@@ -28,6 +28,16 @@ class WFCUtils:
             print("WFCUtils::expand_wfcs")
 
         wfcs = ""
+        
+        # Check if the WFCs list contain "\j" join command
+        join_pos = wfc_list.find("\\j")
+        if join_pos != -1:
+            wfc_list = wfc_list[join_pos+2:]
+
+        # Check if the WFCs list contain "\m" map command
+        map_pos = wfc_list.find("\\m")
+        if map_pos != -1:
+            wfc_list = wfc_list[map_pos+2:]
 
         # Check if the WFCs list contain "\r" repeat command
         repeat_pos = wfc_list.find("\\r")

--- a/Semi_ATE/STIL/parsers/grammars/b_signal_groups.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_signal_groups.lark
@@ -1,5 +1,6 @@
 %import base.SIGNAL_NAME_TERMINAL
 %import base.WFC_LIST
+%import base.WFC
 %import base.INT
 %import base.USER_DEFINED_NAME
 %import base.scan_type
@@ -31,7 +32,7 @@ OPEN_SIGNAL_GROUPS_BLOCK : "{"
 CLOSE_SIGNAL_GROUPS_BLOCK : "}"
 
 //  signal_attributes : "{"                    (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count)* "}"
-    signal_attributes : OPEN_SIGNAL_ATTR_BLOCK (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count)* CLOSE_SIGNAL_ATTR_BLOCK
+    signal_attributes : OPEN_SIGNAL_ATTR_BLOCK (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count | wfcmap)* CLOSE_SIGNAL_ATTR_BLOCK
 
     OPEN_SIGNAL_ATTR_BLOCK : "{"
 
@@ -65,5 +66,15 @@ CLOSE_SIGNAL_GROUPS_BLOCK : "}"
 //      data_bit_count  : "DataBitCount"       INT ";" 
         data_bit_count  : KEYWORD_DATABITCOUNT INT ";" 
         KEYWORD_DATABITCOUNT : "DataBitCount"
+
+//      wfcmap from IEEE 1450.1 Design
+        wfcmap  : KEYWORD_WFCMAP OPEN_WFCMAP_BLOCK (one2many | two2one)* CLOSE_WFCMAP_BLOCK 
+        KEYWORD_WFCMAP: "WFCMap"
+    
+        one2many : WFC "->" WFC_LIST ";"
+        two2one : WFC (WFC) "->" WFC ";"
+
+        OPEN_WFCMAP_BLOCK : "{"
+        CLOSE_WFCMAP_BLOCK : "}"
 
     CLOSE_SIGNAL_ATTR_BLOCK : "}"

--- a/Semi_ATE/STIL/parsers/grammars/b_signals.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_signals.lark
@@ -1,5 +1,6 @@
 %import base.SIGNAL_NAME_TERMINAL
 %import base.WFC_LIST
+%import base.WFC
 %import base.INT
 %import base.ANN_TEXT
 %import base.scan_type
@@ -25,8 +26,8 @@ OPEN_SIGNAL_BLOCK : "{"
     
     SIGNAL_END_STMT : ";"
     
-//  signal_attributes : "{"                    (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count)* "}"
-    signal_attributes : OPEN_SIGNAL_ATTR_BLOCK (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count)* CLOSE_SIGNAL_ATTR_BLOCK
+//  signal_attributes : "{"                    (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count | wfcmap)* "}"
+    signal_attributes : OPEN_SIGNAL_ATTR_BLOCK (termination | default_state | base | alignment | scan_in | scan_out | data_bit_count | wfcmap)* CLOSE_SIGNAL_ATTR_BLOCK
 
     OPEN_SIGNAL_ATTR_BLOCK : "{"
 
@@ -60,6 +61,17 @@ OPEN_SIGNAL_BLOCK : "{"
 //      data_bit_count  : "DataBitCount"       INT ";" 
         data_bit_count  : KEYWORD_DATABITCOUNT INT ";" 
         KEYWORD_DATABITCOUNT : "DataBitCount"
+        
+//      wfcmap from IEEE 1450.1 Design
+        wfcmap  : KEYWORD_WFCMAP OPEN_WFCMAP_BLOCK (one2many | two2one)* CLOSE_WFCMAP_BLOCK 
+        KEYWORD_WFCMAP: "WFCMap"
+    
+        one2many : WFC "->" WFC_LIST ";"
+        two2one : WFC (WFC) "->" WFC ";"
+    
+        OPEN_WFCMAP_BLOCK : "{"
+        CLOSE_WFCMAP_BLOCK : "}"
+
 
     CLOSE_SIGNAL_ATTR_BLOCK : "}"
     

--- a/Semi_ATE/STIL/parsers/grammars/b_spec.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_spec.lark
@@ -4,43 +4,46 @@
 %import base.TYP
 %import base.MAX
 
-spec_block : (category_spec | variable_spec)
-
-//category_spec: "Spec"         [SPEC_DOMAIN_NAME] "{"             (category)* "}"
-  category_spec: KEYWORD_SPEC   [SPEC_DOMAIN_NAME] OPEN_SPEC_BLOCK (category)* CLOSE_SPEC_BLOCK
+//spec_block: "Spec"         [SPEC_DOMAIN_NAME] "{"             (category_spec | variable_spec)* "}"
+  spec_block: KEYWORD_SPEC   [SPEC_DOMAIN_NAME] OPEN_SPEC_BLOCK (category_spec | variable_spec)* CLOSE_SPEC_BLOCK
 KEYWORD_SPEC : "Spec"
 
 SPEC_DOMAIN_NAME : USER_DEFINED_NAME
  
 OPEN_SPEC_BLOCK : "{"
 
-//  category: "Category"        USER_DEFINED_NAME "{"                 (cat_typ | cat_all)* "}"
-    category : KEYWORD_CATEGORY USER_DEFINED_NAME open_category_block (cat_typ | cat_all)* close_category_block
+//  category_spec: "Category"        USER_DEFINED_NAME "{"                 (var_typ | var_all)* "}"
+    category_spec : KEYWORD_CATEGORY USER_DEFINED_NAME open_category_block (var_typ | var_all)* close_category_block
     KEYWORD_CATEGORY : "Category"
 
     open_category_block : "{"
     
-        cat_typ : USER_DEFINED_NAME "=" TIME_EXPR ";"
+        var_typ : USER_DEFINED_NAME "=" TIME_EXPR ";"
 
-//      cat_all : USER_DEFINED_NAME "{"                     ((MIN|TYP|MAX) TIME_EXPR ";")* "}"
-        cat_all : USER_DEFINED_NAME open_category_all_block ((MIN|TYP|MAX) TIME_EXPR ";")* close_category_all_block
+//      var_all : USER_DEFINED_NAME "{"                ((MIN|TYP|MAX) TIME_EXPR ";")* "}"
+        var_all : USER_DEFINED_NAME open_var_all_block ((MIN|TYP|MAX) TIME_EXPR ";")* close_var_all_block
 
-        open_category_all_block : "{"
-        close_category_all_block : "}"
+        open_var_all_block : "{"
+        close_var_all_block : "}"
         
     close_category_block : "}"
 
+    open_var_block : "{"
+
+//  variable_spec: "Variable"        USER_DEFINED_NAME "{"            (cat_typ | cat_all)* "}"
+    variable_spec : KEYWORD_VARIABLE USER_DEFINED_NAME open_var_block (cat_typ | cat_all)* close_var_block 
+    KEYWORD_VARIABLE : "Variable"
+
+        cat_typ : USER_DEFINED_NAME "=" TIME_EXPR ";"
+
+//      cat_all : USER_DEFINED_NAME "{"                ((MIN|TYP|MAX) TIME_EXPR ";")* "}"
+        cat_all : USER_DEFINED_NAME open_cat_all_block ((MIN|TYP|MAX) TIME_EXPR ";")* close_cat_all_block
+
+        open_cat_all_block : "{"
+        close_cat_all_block : "}"
+
+    close_var_block : "}"
+
 CLOSE_SPEC_BLOCK : "}"
 
-//variable_spec: "Spec"         USER_DEFINED_NAME "{"                 variable "}"
-  variable_spec: KEYWORD_SPEC   USER_DEFINED_NAME open_spec_var_block variable close_spec_var_block
-
-open_spec_var_block : "{"
-
-    variable : KEYWORD_VARIABLE USER_DEFINED_NAME open_var_block (USER_DEFINED_NAME (MIN|TYP|MAX)* ";")* close_var_block 
-    KEYWORD_VARIABLE : "Variable"
-    open_var_block : "{"
-    close_var_block : "}"
-    
-close_spec_var_block : "}"
 

--- a/Semi_ATE/STIL/parsers/grammars/b_timing.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_timing.lark
@@ -33,8 +33,8 @@ OPEN_TIMING_BLOCK : "{"
         
             OPEN_WAVEFORMS_BLOCK : "{" 
             
-//              waveforms_list : WF_SIGREF_EXPR "{"            WFC_LIST "{"              (wfcs_definition)+  "}"              "}"
-                waveforms_list : WF_SIGREF_EXPR OPEN_WFC_BLOCK WFC_LIST OPEN_WFCS_BLOCK  (wfcs_definition)+  CLOSE_WFCS_BLOCK CLOSE_WFC_BLOCK
+//              waveforms_list : WF_SIGREF_EXPR "{"            WFC_LIST "{"              (time_offset)+  "}"              "}"
+                waveforms_list : WF_SIGREF_EXPR OPEN_WFC_BLOCK WFC_LIST OPEN_WFCS_BLOCK  (time_offset)+  CLOSE_WFCS_BLOCK CLOSE_WFC_BLOCK
 
                 WF_SIGREF_EXPR : SIGNAL_NAME_TERMINAL 
 
@@ -44,7 +44,7 @@ OPEN_TIMING_BLOCK : "{"
 
                         OPEN_WFCS_BLOCK : "{"
 
-                            wfcs_definition: TIME_EXPR (EVENT | events) ";" 
+                            time_offset: TIME_EXPR (EVENT | events) ";" 
                             events : EVENT ("/" EVENT)+
                             EVENT  : (  "ForceDown"         | "D" 
                                       | "ForceUp"           | "U" 

--- a/Semi_ATE/STIL/parsers/grammars/base.lark
+++ b/Semi_ATE/STIL/parsers/grammars/base.lark
@@ -2,6 +2,7 @@
 
 
 WFC_LIST : /[A-Za-z0-9]+/
+WFC : /[A-Za-z0-9]/
 IDENTIFICATOR : /[A-Za-z_][A-Za-z0-9_]*/
 LETTER : /[A-Za-z]/ 
 IDENTIFIER : (LETTER|DIGIT|"_")+
@@ -46,12 +47,28 @@ YEAR : /(19|[2-9][0-9])[0-9]{2}/
 // =============================================================================
 
 // =============================================================================
-// ============================= TIME ==========================================
+// ============================= TIME_EXPR =====================================
 
-TIME_EXPR : "'"  (NUMBER | EXP) TIME_UNIT "'" 
+TIME_EXPR : "'" OPEN_MARK EXPR ( OP OPEN_MARK EXPR CLOSE_MARK )* CLOSE_MARK "'"
+
+WS : (" ")*
+OPEN_MARK  :  WS ("(")* WS
+CLOSE_MARK :  WS (")")* WS
+
+OP : WS TIME_EXPR_ADD WS | WS TIME_EXPR_SUB WS| WS TIME_EXPR_DIV WS | WS TIME_EXPR_MUL WS | WS
+
+TIME_EXPR_ADD : "+"
+TIME_EXPR_SUB : "-"
+TIME_EXPR_DIV : "/"
+TIME_EXPR_MUL : "*"
+
+EXPR : TIME_EXPR_VAR | (NUMBER | EXP) (TIME_UNIT|FREQ_UNIT)*
+
+TIME_EXPR_VAR : USER_DEFINED_NAME
 
 EXP : NUMBER ("e"|"E") ("+"|"-")  INT
 
+FREQ_UNIT :  ("aHz"|"fHz"|"pHz"|"nHz"|"uHz"|"mHz"|"Hz"|"kHz"|"MHz"|"GHz"|"THz"|"PHz"|"EHz") 
 TIME_UNIT :  ("as"|"fs"|"ps"|"ns"|"us"|"ms"|"s"|"ks"|"Ms"|"Gs"|"Ts"|"Ps"|"Es") 
 
 // ========================= End of TIME =======================================

--- a/Semi_ATE/STIL/parsers/grammars/pattern_statements.lark
+++ b/Semi_ATE/STIL/parsers/grammars/pattern_statements.lark
@@ -39,7 +39,7 @@ CLOSE_VECTOR_BLOCK : "}"
 
     vec_data_block: SIGREF_EXPR "=" VEC_DATA_STRING
     SIGREF_EXPR : USER_DEFINED_NAME
-    VEC_DATA_STRING : /[A-Za-z0-9%#\\r\n ]+/
+    VEC_DATA_STRING : /[A-Za-z0-9%#\\r\\j\\m\n ]+/
 
 
 //w_stmt : ("W"       | "WaveformTable")        WAVEFORM_TABLE_NAME ";"
@@ -60,7 +60,7 @@ CLOSE_VECTOR_BLOCK : "}"
     OPEN_MACRO_VECTOR_BLOCK  : "{"
       macro_vec_data_block: MACRO_SIGREF_EXPR "=" MACRO_VEC_DATA_STRING
       MACRO_SIGREF_EXPR : USER_DEFINED_NAME
-      MACRO_VEC_DATA_STRING : /[A-Za-z0-9%#\\r\n ]+/
+      MACRO_VEC_DATA_STRING : /[A-Za-z0-9%#\\r\\j\\m\n ]+/
     CLOSE_MACRO_VECTOR_BLOCK : "}"
 
 //call_stmt : "Call"        CALL_PROC_NAME (";" | call_vec_block)
@@ -74,7 +74,7 @@ CLOSE_VECTOR_BLOCK : "}"
     OPEN_CALL_VECTOR_BLOCK  : "{"
       call_vec_data_block: CALL_SIGREF_EXPR "=" CALL_VEC_DATA_STRING
       CALL_SIGREF_EXPR : USER_DEFINED_NAME
-      CALL_VEC_DATA_STRING : /[A-Za-z0-9%#\\r\n ]+/
+      CALL_VEC_DATA_STRING : /[A-Za-z0-9%#\\r\\j\\m\n ]+/
     CLOSE_CALL_VECTOR_BLOCK : "}"
 
 //l_stmt : "Loop"       LOOP_COUNT "{"             (pattern_statement)* "}"
@@ -113,12 +113,14 @@ CLOSE_VECTOR_BLOCK : "}"
 
 
 //i_stmt : "IddqTestPoint" ";"
-  i_stmt : KEYWORD_IDDQ_TEST_POINT ";"
+  i_stmt : (KEYWORD_IDDQ_TEST_POINT ";" | KEYWORD_IDDQ_TEST_POINT_SC)
   KEYWORD_IDDQ_TEST_POINT: "IDDQTestPoint"
+  KEYWORD_IDDQ_TEST_POINT_SC: "IDDQTestPoint;"
 
 //s_stmt : "Stop" ";"
-  s_stmt : KEYWORD_STOP ";"
+  s_stmt : (KEYWORD_STOP ";" | KEYWORD_STOP_SC)
   KEYWORD_STOP : "Stop"
+  KEYWORD_STOP_SC : "Stop;"
 
 //sc_stmt : "ScanChain" USER_DEFINED_NAME ";"
   sc_stmt : KEYWORD_SCAN_CHAIN  SCANCHAIN_NAME ";"

--- a/tests/stil_files/include/signals.stil
+++ b/tests/stil_files/include/signals.stil
@@ -1,0 +1,11 @@
+STIL 1.0;
+
+Signals {
+
+    sig1 In;
+    sig2 Out;
+    sig3 InOut;
+
+}
+
+// PASS

--- a/tests/stil_files/include/signals_w_err.stil
+++ b/tests/stil_files/include/signals_w_err.stil
@@ -1,0 +1,9 @@
+STIL 1.0;
+
+Signals {
+
+    sig1 UnkwownType;
+
+}
+
+// Fail due signal type error.

--- a/tests/stil_files/include/syn_err_include_1.stil
+++ b/tests/stil_files/include/syn_err_include_1.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include
+
+// ERROR : Missing file location and semi-colon termination

--- a/tests/stil_files/include/syn_err_include_2.stil
+++ b/tests/stil_files/include/syn_err_include_2.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include ;
+
+// ERROR : Missing file location

--- a/tests/stil_files/include/syn_err_include_3.stil
+++ b/tests/stil_files/include/syn_err_include_3.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals.stil"
+
+// ERROR : Missing semi-colon teminatio

--- a/tests/stil_files/include/syn_err_include_4.stil
+++ b/tests/stil_files/include/syn_err_include_4.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals.stil" WRONG_KEYWORD
+
+// ERROR : Wrong IfNeed keyword

--- a/tests/stil_files/include/syn_err_include_5.stil
+++ b/tests/stil_files/include/syn_err_include_5.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals.stil" IfNeed ;
+
+// ERROR : Wrong IfNeed keyword

--- a/tests/stil_files/include/syn_err_include_6.stil
+++ b/tests/stil_files/include/syn_err_include_6.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals_w_err.stil" ;
+
+// ERROR : error in the included file

--- a/tests/stil_files/include/syn_ok_include_1.stil
+++ b/tests/stil_files/include/syn_ok_include_1.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals_none_exists.stil";
+
+// PASS

--- a/tests/stil_files/include/syn_ok_include_2.stil
+++ b/tests/stil_files/include/syn_ok_include_2.stil
@@ -1,0 +1,14 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+Include "signal_groups_none_exists.stil";
+
+// PASS

--- a/tests/stil_files/include/syn_ok_include_3.stil
+++ b/tests/stil_files/include/syn_ok_include_3.stil
@@ -1,0 +1,17 @@
+STIL 1.0;
+
+Include "header_none_exists.stil" IfNeed Header;
+Include "ann_none_exists.stil" IfNeed Ann;
+Include "signals_none_exists.stil" IfNeed Signals;
+Include "signal_groups_none_exists.stil" IfNeed SignalGroups;
+Include "timing_none_exists.stil" IfNeed Timing;
+Include "signal_groups_none_exists.stil" IfNeed Signals;
+Include "spec_none_exists.stil" IfNeed Spec;
+Include "selector_none_exists.stil" IfNeed Selector;
+Include "procedures_none_exists.stil" IfNeed Procedures;
+Include "macros_none_exists.stil" IfNeed MacroDefs;
+Include "pattern_burst_none_exists.stil" IfNeed PatternBurst;
+Include "pattern_exec_none_exists.stil" IfNeed PatternExec;
+Include "pattern_none_exists.stil" IfNeed Pattern;
+
+// PASS

--- a/tests/stil_files/include/syn_ok_include_4.stil
+++ b/tests/stil_files/include/syn_ok_include_4.stil
@@ -1,0 +1,5 @@
+STIL 1.0;
+
+Include "signals.stil";
+
+// PASS

--- a/tests/stil_files/spec_block/syn_err_spec_block_1.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_1.stil
@@ -1,0 +1,24 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec ;
+// ERROR : Spec is a block and must start with open curly bracket '{'

--- a/tests/stil_files/spec_block/syn_err_spec_block_10.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_10.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var ;
+  }
+}
+// ERROR : not defined variable 

--- a/tests/stil_files/spec_block/syn_err_spec_block_11.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_11.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat ;
+  }
+}
+// ERROR : not defined category 

--- a/tests/stil_files/spec_block/syn_err_spec_block_12.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_12.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var = ;
+  }
+}
+// ERROR : missing value for the variable 

--- a/tests/stil_files/spec_block/syn_err_spec_block_13.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_13.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat = ;
+  }
+}
+// ERROR : missing value for the category 

--- a/tests/stil_files/spec_block/syn_err_spec_block_14.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_14.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var = 1.23;
+  }
+}
+// ERROR : missing single quotes for time expression value for the variable 

--- a/tests/stil_files/spec_block/syn_err_spec_block_15.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_15.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat = 1.23;
+  }
+}
+// ERROR : missing single quotes for time expression value for the category 

--- a/tests/stil_files/spec_block/syn_err_spec_block_16.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_16.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var = '1.23'
+  }
+}
+// ERROR : missing semi-colon termination after the time expression

--- a/tests/stil_files/spec_block/syn_err_spec_block_17.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_17.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat = '1.23'
+  }
+}
+// ERROR : missing semi-colon termination after the time expression

--- a/tests/stil_files/spec_block/syn_err_spec_block_18.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_18.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var {MinX '1.23MHz';}
+  }
+}
+// ERROR : not valid keyword - Min 

--- a/tests/stil_files/spec_block/syn_err_spec_block_19.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_19.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat { MinX '1.23';}
+  }
+}
+// ERROR : missing semi-colon termination after the time expression

--- a/tests/stil_files/spec_block/syn_err_spec_block_2.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_2.stil
@@ -1,0 +1,24 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name ;
+// ERROR : Spec is a block and must start with open curly bracket '{'

--- a/tests/stil_files/spec_block/syn_err_spec_block_20.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_20.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+      var {Max '10MHz'; Typ '5MHz'; Min '1MHz'}
+  }
+}
+// ERROR : missing semi-colon termination after the time expression

--- a/tests/stil_files/spec_block/syn_err_spec_block_21.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_21.stil
@@ -1,0 +1,28 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+      cat {Max '10MHz'; Typ '5MHz'; Min '1MHz'}
+  }
+}
+// ERROR : missing semi-colon termination after the time expression

--- a/tests/stil_files/spec_block/syn_err_spec_block_3.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_3.stil
@@ -1,0 +1,24 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec { 
+// ERROR : Spec is a block and must end with closed curly bracket '}'

--- a/tests/stil_files/spec_block/syn_err_spec_block_4.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_4.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category {}
+}
+// ERROR : Category must have a name

--- a/tests/stil_files/spec_block/syn_err_spec_block_5.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_5.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable {}
+}
+// ERROR : Variable must have a name

--- a/tests/stil_files/spec_block/syn_err_spec_block_6.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_6.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name;
+}
+// ERROR : Category is a block

--- a/tests/stil_files/spec_block/syn_err_spec_block_7.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_7.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name;
+}
+// ERROR : Variable is a block

--- a/tests/stil_files/spec_block/syn_err_spec_block_8.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_8.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+}
+// ERROR : Missing closing brackets in the Category block 

--- a/tests/stil_files/spec_block/syn_err_spec_block_9.stil
+++ b/tests/stil_files/spec_block/syn_err_spec_block_9.stil
@@ -1,0 +1,26 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Variable name {
+}
+// ERROR : Missing closing brackets in the Variable block 

--- a/tests/stil_files/spec_block/syn_ok_spec_block_1.stil
+++ b/tests/stil_files/spec_block/syn_ok_spec_block_1.stil
@@ -1,0 +1,25 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+}
+// PASS : empty block 

--- a/tests/stil_files/spec_block/syn_ok_spec_block_2.stil
+++ b/tests/stil_files/spec_block/syn_ok_spec_block_2.stil
@@ -1,0 +1,93 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  Category name {
+
+      time = '1us';
+
+      time_a {Min '1as'; Typ '1.5as'; Max '2e-1as' ;}
+      time_f {Min '1fs'; Typ '1.5fs'; Max '2e-1fs' ;}
+      time_p {Min '1ps'; Typ '1.5ps'; Max '2e-1ps' ;}
+      time_n {Min '1ns'; Typ '1.5ns'; Max '2e-1ns' ;}
+      time_u {Min '1us'; Typ '1.5us'; Max '2e-1us' ;}
+      time_m {Min '1ms'; Typ '1.5ms'; Max '2e-1ms' ;}
+      time_s {Min '1s'; Typ '1.5s'; Max '2e-1s' ;}
+      time_k {Min '1ks'; Typ '1.5ks'; Max '2e-1ks' ;}
+      time_M {Min '1Ms'; Typ '1.5Ms'; Max '2e-1Ms' ;}
+      time_G {Min '1Gs'; Typ '1.5Gs'; Max '2e-1Gs' ;}
+      time_T {Min '1Ts'; Typ '1.5Ts'; Max '2e-1Ts' ;}
+      time_P {Min '1Ps'; Typ '1.5Ps'; Max '2e-1Ps' ;}
+      time_E {Min '1Es'; Typ '1.5Es'; Max '2e-1Es' ;}
+
+      freq = '1MHz';
+      
+      freq_a {Min '1aHz'; Typ '1.5aHz'; Max '2e-1aHz' ;}
+      freq_f {Min '1fHz'; Typ '1.5fHz'; Max '2e-1fHz' ;}
+      freq_p {Min '1pHz'; Typ '1.5pHz'; Max '2e-1pHz' ;}
+      freq_n {Min '1nHz'; Typ '1.5nHz'; Max '2e-1nHz' ;}
+      freq_u {Min '1uHz'; Typ '1.5uHz'; Max '2e-1uHz' ;}
+      freq_m {Min '1mHz'; Typ '1.5mHz'; Max '2e-1mHz' ;}
+      freq_h {Min '1Hz'; Typ '1.5Hz'; Max '2e-1Hz' ;}
+      freq_k {Min '1kHz'; Typ '1.5kHz'; Max '2e-1kHz' ;}
+      freq_M {Min '1MHz'; Typ '1.5MHz'; Max '2e-1MHz' ;}
+      freq_G {Min '1GHz'; Typ '1.5GHz'; Max '2e-1GHz' ;}
+      freq_T {Min '1THz'; Typ '1.5THz'; Max '2e-1THz' ;}
+      freq_P {Min '1PHz'; Typ '1.5PHz'; Max '2e-1PHz' ;}
+      freq_E {Min '1EHz'; Typ '1.5EHz'; Max '2e-1EHz' ;}
+  }
+  Variable name {
+
+      time = '1us';
+
+      time_a {Min '1as'; Typ '1.5as'; Max '2e-1as' ;}
+      time_f {Min '1fs'; Typ '1.5fs'; Max '2e-1fs' ;}
+      time_p {Min '1ps'; Typ '1.5ps'; Max '2e-1ps' ;}
+      time_n {Min '1ns'; Typ '1.5ns'; Max '2e-1ns' ;}
+      time_u {Min '1us'; Typ '1.5us'; Max '2e-1us' ;}
+      time_m {Min '1ms'; Typ '1.5ms'; Max '2e-1ms' ;}
+      time_s {Min '1s'; Typ '1.5s'; Max '2e-1s' ;}
+      time_k {Min '1ks'; Typ '1.5ks'; Max '2e-1ks' ;}
+      time_M {Min '1Ms'; Typ '1.5Ms'; Max '2e-1Ms' ;}
+      time_G {Min '1Gs'; Typ '1.5Gs'; Max '2e-1Gs' ;}
+      time_T {Min '1Ts'; Typ '1.5Ts'; Max '2e-1Ts' ;}
+      time_P {Min '1Ps'; Typ '1.5Ps'; Max '2e-1Ps' ;}
+      time_E {Min '1Es'; Typ '1.5Es'; Max '2e-1Es' ;}
+
+      freq = '1MHz';
+      
+      freq_a {Min '1aHz'; Typ '1.5aHz'; Max '2e-1aHz' ;}
+      freq_f {Min '1fHz'; Typ '1.5fHz'; Max '2e-1fHz' ;}
+      freq_p {Min '1pHz'; Typ '1.5pHz'; Max '2e-1pHz' ;}
+      freq_n {Min '1nHz'; Typ '1.5nHz'; Max '2e-1nHz' ;}
+      freq_u {Min '1uHz'; Typ '1.5uHz'; Max '2e-1uHz' ;}
+      freq_m {Min '1mHz'; Typ '1.5mHz'; Max '2e-1mHz' ;}
+      freq_h {Min '1Hz'; Typ '1.5Hz'; Max '2e-1Hz' ;}
+      freq_k {Min '1kHz'; Typ '1.5kHz'; Max '2e-1kHz' ;}
+      freq_M {Min '1MHz'; Typ '1.5MHz'; Max '2e-1MHz' ;}
+      freq_G {Min '1GHz'; Typ '1.5GHz'; Max '2e-1GHz' ;}
+      freq_T {Min '1THz'; Typ '1.5THz'; Max '2e-1THz' ;}
+      freq_P {Min '1PHz'; Typ '1.5PHz'; Max '2e-1PHz' ;}
+      freq_E {Min '1EHz'; Typ '1.5EHz'; Max '2e-1EHz' ;}
+  }
+}
+// PASS : test time and frequency units

--- a/tests/stil_files/spec_block/syn_ok_spec_block_3.stil
+++ b/tests/stil_files/spec_block/syn_ok_spec_block_3.stil
@@ -1,0 +1,57 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+SignalGroups sg { 
+    si = 'si1 + si2';
+    so = 'so1 + so2';
+    sio = 'sio1 + sio2';
+    all = 'si + so + sio';
+}
+
+Spec domain_name { 
+  
+  Category name {
+  
+      time_add_1 = '1.0us+2.0us';
+      time_add_2 = '1.0us + 2us+3us';
+      time_sub_1 = '1.0us-2us';
+      time_sub_2 = '1.0us - 2us-3us';
+      time_mul_1 = '1.0us*2us';
+      time_mul_2 = '1.0us * 2us*3us';
+      time_div_1 = '1.0us/2';
+      time_div_2 = '1.0us * 2/3';
+
+      time_mix_1 = '1.0us+2us-(3us*1.5)/2.0';
+      time_mix_2 = '(1.0us*2)+5us';
+      time_mix_3 = '(1.0us*2) + offset';
+
+  }
+  Variable name {
+
+      time_add_1 = '1.0us+2.0us';
+      time_add_2 = '1.0us + 2us+3us';
+      time_sub_1 = '1.0us-2us';
+      time_sub_2 = '1.0us - 2us-3us';
+      time_mul_1 = '1.0us*2us';
+      time_mul_2 = '1.0us * 2us*3us';
+      time_div_1 = '1.0us/2';
+      time_div_2 = '1.0us * 2/3';
+
+      time_mix_1 = '1.0us+2us-(3us*1.5)/2.0';
+      time_mix_2 = '(1.0us*2)+5us';
+      time_mix_3 = '(1.0us*2) + offset';
+  }
+}
+// PASS : Different types of time expressions

--- a/tests/stil_files/timing_block/syn_err_timing_block_17.stil
+++ b/tests/stil_files/timing_block/syn_err_timing_block_17.stil
@@ -25,8 +25,8 @@ Timing {
   { Period '10ms';
       Waveforms 
       {
-        si1 {A {'10kg' D;}}
+        si1 {A {'' D;}}
       }
   }
 }
-// ERROR : wrong time unit for the Waveform event
+// ERROR : missing time expression for the Waveform event

--- a/tests/stil_files/timing_block/syn_err_timing_block_8.stil
+++ b/tests/stil_files/timing_block/syn_err_timing_block_8.stil
@@ -22,7 +22,7 @@ SignalGroups sg {
 
 Timing { 
   WaveformTable wft 
-  { Period 'value' ;
+  { Period '' ;
       Waveforms 
       {
         si1 {A {'0ns'  D;}}

--- a/tests/stil_files/timing_block/syn_err_timing_block_9.stil
+++ b/tests/stil_files/timing_block/syn_err_timing_block_9.stil
@@ -22,7 +22,7 @@ SignalGroups sg {
 
 Timing { 
   WaveformTable wft 
-  { Period '10ws';
+  { Period "wrong";
       Waveforms 
       {
         si1 {A {'0ns'  D;}}

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+try:
+    from Semi_ATE.STIL.parsers.STILParser import STILParser
+except:
+    cwd = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, cwd)
+    from Semi_ATE.STIL.parsers.STILParser import STILParser
+
+
+def get_stil_file(file_name):
+    folder = os.path.dirname(__file__)
+    return os.path.join(str(folder), "stil_files", "include", file_name)
+
+
+def test_syn_err_include_1():
+    stil_file = get_stil_file("syn_err_include_1.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == 3
+    assert parser.err_col == 1
+
+def test_syn_err_include_2():
+    stil_file = get_stil_file("syn_err_include_2.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == 3
+    assert parser.err_col == 9
+
+def test_syn_err_include_3():
+    stil_file = get_stil_file("syn_err_include_3.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == 3
+    assert parser.err_col == 9
+
+def test_syn_err_include_4():
+    stil_file = get_stil_file("syn_err_include_4.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == 3
+    assert parser.err_col == 24
+
+def test_syn_err_include_5():
+    stil_file = get_stil_file("syn_err_include_5.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == 3
+    assert parser.err_col == 31
+
+def test_syn_err_include_6():
+    stil_file = get_stil_file("syn_err_include_6.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 6
+    assert parser.err_col == 10
+
+    inc_stil_file = stil_file + ".wo_include"
+    if os.path.exists(inc_stil_file):
+        os.remove(inc_stil_file)
+
+def test_syn_ok_include_1():
+    stil_file = get_stil_file("syn_ok_include_1.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == -1
+    assert parser.err_col == -1
+
+def test_syn_ok_include_2():
+    stil_file = get_stil_file("syn_ok_include_2.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == -1
+    assert parser.err_col == -1
+
+def test_syn_ok_include_3():
+    stil_file = get_stil_file("syn_ok_include_3.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax(preprocess_include = False)
+    assert parser.err_line == -1
+    assert parser.err_col == -1
+
+
+def test_syn_ok_include_4():
+    stil_file = get_stil_file("syn_ok_include_4.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == -1
+    assert parser.err_col == -1
+    
+    inc_stil_file = stil_file + ".wo_include"
+    if os.path.exists(inc_stil_file):
+        os.remove(inc_stil_file)
+
+

--- a/tests/test_spec_block.py
+++ b/tests/test_spec_block.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+try:
+    from Semi_ATE.STIL.parsers.STILParser import STILParser
+except:
+    cwd = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, cwd)
+    from Semi_ATE.STIL.parsers.STILParser import STILParser
+
+
+def get_stil_file(file_name):
+    folder = os.path.dirname(__file__)
+    return os.path.join(str(folder), "stil_files", "spec_block", file_name)
+
+
+def test_syn_err_spec_block_1():
+    stil_file = get_stil_file("syn_err_spec_block_1.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 23
+    assert parser.err_col == 6
+
+def test_syn_err_spec_block_2():
+    stil_file = get_stil_file("syn_err_spec_block_2.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 23
+    assert parser.err_col == 18
+
+def test_syn_err_spec_block_3():
+    stil_file = get_stil_file("syn_err_spec_block_3.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 23
+    assert parser.err_col == 6
+
+def test_syn_err_spec_block_4():
+    stil_file = get_stil_file("syn_err_spec_block_4.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 24    
+    assert parser.err_col == 12
+
+def test_syn_err_spec_block_5():
+    stil_file = get_stil_file("syn_err_spec_block_5.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 24    
+    assert parser.err_col == 12
+
+def test_syn_err_spec_block_6():
+    stil_file = get_stil_file("syn_err_spec_block_6.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 24    
+    assert parser.err_col == 16
+
+def test_syn_err_spec_block_7():
+    stil_file = get_stil_file("syn_err_spec_block_7.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 24    
+    assert parser.err_col == 16
+
+def test_syn_err_spec_block_8():
+    stil_file = get_stil_file("syn_err_spec_block_8.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 1
+
+def test_syn_err_spec_block_9():
+    stil_file = get_stil_file("syn_err_spec_block_9.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 1
+
+def test_syn_err_spec_block_10():
+    stil_file = get_stil_file("syn_err_spec_block_10.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 11
+
+def test_syn_err_spec_block_11():
+    stil_file = get_stil_file("syn_err_spec_block_11.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 11
+
+def test_syn_err_spec_block_12():
+    stil_file = get_stil_file("syn_err_spec_block_12.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 13
+
+def test_syn_err_spec_block_13():
+    stil_file = get_stil_file("syn_err_spec_block_13.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 13
+
+def test_syn_err_spec_block_14():
+    stil_file = get_stil_file("syn_err_spec_block_14.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 13
+
+def test_syn_err_spec_block_15():
+    stil_file = get_stil_file("syn_err_spec_block_15.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 13
+
+def test_syn_err_spec_block_16():
+    stil_file = get_stil_file("syn_err_spec_block_16.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 26
+    assert parser.err_col == 3
+
+def test_syn_err_spec_block_17():
+    stil_file = get_stil_file("syn_err_spec_block_17.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 26
+    assert parser.err_col == 3
+
+def test_syn_err_spec_block_18():
+    stil_file = get_stil_file("syn_err_spec_block_18.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 15
+
+def test_syn_err_spec_block_19():
+    stil_file = get_stil_file("syn_err_spec_block_19.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 16
+
+def test_syn_err_spec_block_20():
+    stil_file = get_stil_file("syn_err_spec_block_20.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 47
+
+def test_syn_err_spec_block_21():
+    stil_file = get_stil_file("syn_err_spec_block_21.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == 25
+    assert parser.err_col == 47
+
+def test_syn_ok_spec_block_1():
+    stil_file = get_stil_file("syn_ok_spec_block_1.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == -1    
+    assert parser.err_col == -1
+
+def test_syn_ok_spec_block_2():
+    stil_file = get_stil_file("syn_ok_spec_block_2.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == -1    
+    assert parser.err_col == -1
+
+def test_syn_ok_spec_block_3():
+    stil_file = get_stil_file("syn_ok_spec_block_3.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    assert parser.err_line == -1    
+    assert parser.err_col == -1

--- a/tests/test_timing_block.py
+++ b/tests/test_timing_block.py
@@ -184,7 +184,6 @@ def test_syn_err_timing_block_21():
     assert parser.err_line == 28
     assert parser.err_col == 14
 
-
 def test_syn_ok_timing_block_1():
     stil_file = get_stil_file("syn_ok_timing_block_1.stil")
 


### PR DESCRIPTION
Added support for IEEE 1450.0 for the following keywords/features in the syntax parser:
- Include, IfNeed BLOCK, where BLOCK is : STIL, Header, Signals, SignalGroups, ScanStructures, Spec, Timing,
Selector, PatternBurst PatternExec, Procedures, MacroDefs, Pattern, UserKeywords, UserFunctions, Ann).
Does not support syntax error highlighting yet.
- Frequency in the Timing block
- Constants from spec in the Timing block
- Math operations in the timing block : +, -, /, *
- Parentesis  in the "(,)"

Added support for TetraMax ATPG SW when STIL is exported with "STIL" option (not STIL99).
- WFCMap in Signals and ScanChainGroups
- \j 
- \m

Small improvements in the syntax parser :
Added support for "label :"
Added support for "Stop;", "IDDQTestPoint;"

Added more unit tests.