### PR TITLE
Implement issue 55. 

### DIFF
--- a/Semi_ATE/STIL/parsers/PatternExecBlockParser.py
+++ b/Semi_ATE/STIL/parsers/PatternExecBlockParser.py
@@ -257,8 +257,19 @@ class PatternExecBlockParser:
                 pass
 
         # The time is expressoin, let's calculate it:
-        cat = self.patt_exec2category[self.curr_patt_exec]
-        sel = self.patt_exec2selector[self.curr_patt_exec]
+        if self.curr_patt_exec in self.patt_exec2category:
+            cat = self.patt_exec2category[self.curr_patt_exec]
+        else:
+            domain_name = DomainUtils.get_domain(self.curr_patt_exec, True)
+            err_msg = f"ERROR: Trying to find value for time expression {time_expr}, but Category is missing in the {domain_name} PatternExec block"
+            raise Exception(err_msg)
+
+        if self.curr_patt_exec in self.patt_exec2selector:
+            sel = self.patt_exec2selector[self.curr_patt_exec]
+        else:
+            domain_name = DomainUtils.get_domain(self.curr_patt_exec, True)
+            err_msg = f"ERROR: Trying to find value for time expression {time_expr}, but Selector is missing in the {domain_name} PatternExec block"
+            raise Exception(err_msg)
             
         op_list = []
 

--- a/Semi_ATE/STIL/parsers/STILParser.py
+++ b/Semi_ATE/STIL/parsers/STILParser.py
@@ -173,6 +173,9 @@ class STILParser(STILLark):
                         self.tree = self.parser.parse(data.read())
                         if debug == True:
                             print(self.tree.pretty())
+            else:
+                msg = "ERROR : input STIL file does not exists '{self.stil_file}' b"
+                raise Exception(msg)
 
             if debug:
                 print("\nEnd of syntax parsing")
@@ -307,4 +310,5 @@ class STILParser(STILLark):
                 print(self.err_msg)
 
         else:
-            print("ERROR : syntax parsing must be performed before semantic analisys b")
+            msg = "ERROR : syntax parsing must be performed before semantic analisys b"
+            raise Exception(msg)

--- a/Semi_ATE/STIL/parsers/SelectorBlockParser.py
+++ b/Semi_ATE/STIL/parsers/SelectorBlockParser.py
@@ -54,5 +54,12 @@ class SelectorBlockParser:
         if self.debug:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)
+
+        # issue 55 : for all variables which have typ values, but they are not in the Selector
+        for key in self.var_typ_value.keys():
+            s = key.split("::")
+            key = self.curr_selector + "::" + s[1]
+            self.selector_var[key] = "Typ"
+        
             
         self.curr_selector = DomainUtils.global_domain

--- a/Semi_ATE/STIL/parsers/SpecBlockParser.py
+++ b/Semi_ATE/STIL/parsers/SpecBlockParser.py
@@ -63,8 +63,9 @@ class SpecBlockParser:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)
             
-        key = self.curr_spec + "::" + self.curr_category + "::" + self.curr_var_name
-        self.var_typ_value[key] = str(t[0])
+        key = self.curr_category + "::" + self.curr_var_name
+        value = str(t[0]).replace('\'','')
+        self.var_typ_value[key] = value
 
     def b_spec__var_type(self, t):
         if self.debug:

--- a/Semi_ATE/STIL/parsers/grammars/b_selector.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_selector.lark
@@ -4,8 +4,8 @@
 %import base.MAX
 %import base.MEAS
 
-//selector_block : "Selector"       [SELECTOR_DOMAIN_NAME] "{"                 (var_selector)* "}" 
-  selector_block : KEYWORD_SELECTOR [SELECTOR_DOMAIN_NAME] OPEN_SELECTOR_BLOCK (var_selector)* CLOSE_SELECTOR_BLOCK
+//selector_block : "Selector"       SELECTOR_DOMAIN_NAME "{"                 (var_selector)* "}" 
+  selector_block : KEYWORD_SELECTOR SELECTOR_DOMAIN_NAME OPEN_SELECTOR_BLOCK (var_selector)* CLOSE_SELECTOR_BLOCK
 KEYWORD_SELECTOR : "Selector"
 
 SELECTOR_DOMAIN_NAME : USER_DEFINED_NAME

--- a/Semi_ATE/STIL/parsers/grammars/b_spec.lark
+++ b/Semi_ATE/STIL/parsers/grammars/b_spec.lark
@@ -4,8 +4,8 @@
 %import base.TYP
 %import base.MAX
 
-//spec_block: "Spec"         [SPEC_DOMAIN_NAME] "{"             (category_spec | variable_spec)* "}"
-  spec_block: KEYWORD_SPEC   [SPEC_DOMAIN_NAME] OPEN_SPEC_BLOCK (category_spec | variable_spec)* CLOSE_SPEC_BLOCK
+//spec_block: "Spec"         SPEC_DOMAIN_NAME "{"             (category_spec | variable_spec)* "}"
+  spec_block: KEYWORD_SPEC   SPEC_DOMAIN_NAME OPEN_SPEC_BLOCK (category_spec | variable_spec)* CLOSE_SPEC_BLOCK
 KEYWORD_SPEC : "Spec"
 
 SPEC_DOMAIN_NAME : USER_DEFINED_NAME

--- a/tests/stil_files/spec_block/test_issue_55.stil
+++ b/tests/stil_files/spec_block/test_issue_55.stil
@@ -1,0 +1,85 @@
+STIL 1.0;
+
+Signals {
+    si1 In;
+    si2 In;
+    so1 Out;
+    so2 Out;
+    sio1 InOut;
+    sio2 InOut;
+}
+
+SignalGroups { 
+    all = 'si1 + si2 + so1 + so2 + sio1 + sio2';
+}
+
+
+
+Timing {
+
+    WaveformTable wft1{
+        Period 'catvar_wo_typ';
+             Waveforms {
+                 si1 { 01 { '0ns' D; '250ns' U; }}
+                 si2 { 01 { '0ns' D; '250ns' U; }}
+                 so1 { LH { '0ns' L; '250ns' H; }}
+                 so2 { LH { '0ns' L; '250ns' H; }}
+                 sio1 { 01 { '0ns' D; '250ns' U; }}
+                 sio1 { LH { '0ns' L; '250ns' H; }}
+                 sio2 { 01 { '0ns' D; '250ns' U; }}
+                 sio2 { LH { '0ns' L; '250ns' H; }}
+             }
+    }
+    WaveformTable wft2{
+        Period 'var_wo_typ';
+             Waveforms {
+                 si1 { 01 { '0ns' D; '250ns' U; }}
+                 si2 { 01 { '0ns' D; '250ns' U; }}
+                 so1 { LH { '0ns' L; '250ns' H; }}
+                 so2 { LH { '0ns' L; '250ns' H; }}
+                 sio1 { 01 { '0ns' D; '250ns' U; }}
+                 sio1 { LH { '0ns' L; '250ns' H; }}
+                 sio2 { 01 { '0ns' D; '250ns' U; }}
+                 sio2 { LH { '0ns' L; '250ns' H; }}
+             }
+    }
+}
+
+Spec spec_domain_name { 
+  Category spec_category {
+
+      catvar_wo_typ = '1us';
+      catvar_w_spec {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
+
+  }
+  Variable var_wo_typ {
+      spec_category = '10us';
+  }
+
+  Variable var_w_spec {
+      spec_category {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
+  }
+}
+
+
+Selector typSelector {
+        catvar_w_spec Typ;
+        var_w_spec Typ;
+}
+
+PatternBurst patt_burst{
+    PatList { pattern;
+             }
+}
+
+PatternExec {
+    Selector typSelector;
+    Category spec_category;
+    PatternBurst patt_burst;
+}
+
+Pattern pattern{
+
+    W wft1;
+    V {all = 00LH0H;}
+}

--- a/tests/stil_files/timing_block/sem_ok_timing_block_2.stil
+++ b/tests/stil_files/timing_block/sem_ok_timing_block_2.stil
@@ -17,7 +17,7 @@ SignalGroups {
     all = 'si + so + sio';
 }
 
-Spec {
+Spec spec_domain{
     Category default{
         typ_var = '10ns';
         typ_var = '10ns';

--- a/tests/stil_files/timing_block/sem_ok_timing_block_3.stil
+++ b/tests/stil_files/timing_block/sem_ok_timing_block_3.stil
@@ -17,7 +17,7 @@ SignalGroups {
     all = 'si + so + sio';
 }
 
-Spec {
+Spec spec_domain{
     Category default{
         typ_var = '10ns';
         typ_var = '10ns';

--- a/tests/stil_files/timing_block/sem_ok_timing_block_4.stil
+++ b/tests/stil_files/timing_block/sem_ok_timing_block_4.stil
@@ -17,7 +17,7 @@ SignalGroups {
     all = 'si + so + sio';
 }
 
-Spec {
+Spec spec_domain{
     Category default{
         PLL_Time {Min '10ns'; Typ '100ns'; Max '1000nsz'; }
     }

--- a/tests/test_spec_block.py
+++ b/tests/test_spec_block.py
@@ -207,3 +207,13 @@ def test_syn_ok_spec_block_3():
     parser.parse_syntax()
     assert parser.err_line == -1    
     assert parser.err_col == -1
+
+def test_issue_55():
+
+    stil_file = get_stil_file("test_issue_55.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    parser.parse_semantic()
+    assert parser.err_line == -1
+    assert parser.err_col == -1


### PR DESCRIPTION
The following changes has been made:
- Variable with only value (without Min/Typ/Max values) is used in Spec block, will be automatically set to Typ in Selector block if it is missing there.
- Added mandatory domain names for Spec and Selector blocks.
- Proper message is now given when variable is used as time expression, but there is no Selector or Spec block defined in the PatternExec block  