### PR TITLE
Fix issue 60

### DIFF
--- a/Semi_ATE/STIL/parsers/SpecBlockParser.py
+++ b/Semi_ATE/STIL/parsers/SpecBlockParser.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import inspect
-from .DomainUtils import DomainUtils
-
 
 class SpecBlockParser:
     def __init__(self, debug=False):
         self.debug = debug
 
-        self.curr_spec = DomainUtils.global_domain
         self.curr_var_name = None
         self.curr_var_type = None
         self.curr_category = 'NONE'
@@ -33,8 +30,6 @@ class SpecBlockParser:
         if self.debug:
             func_name = inspect.stack()[0][3]
             self.trace(func_name, t)
-
-        self.curr_spec = t.value
 
     def b_spec__OPEN_SPEC_BLOCK(self, t):
         if self.debug:

--- a/tests/stil_files/spec_block/test_issue_60.stil
+++ b/tests/stil_files/spec_block/test_issue_60.stil
@@ -45,7 +45,7 @@ Timing {
     }
 
     WaveformTable wft3{
-        Period 'catvar_w_spec';
+        Period 'nd_catvar_wo_typ';
              Waveforms {
                  si1 { 01 { '0ns' D; '250ns' U; }}
                  si2 { 01 { '0ns' D; '250ns' U; }}
@@ -58,7 +58,7 @@ Timing {
              }
     }
     WaveformTable wft4{
-        Period 'var_w_spec';
+        Period 'nd_var_wo_typ';
              Waveforms {
                  si1 { 01 { '0ns' D; '250ns' U; }}
                  si2 { 01 { '0ns' D; '250ns' U; }}
@@ -76,30 +76,24 @@ Spec spec_domain_name {
   Category spec_category {
 
       catvar_wo_typ = '1us';
-      catvar_w_spec {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
-      catvar_w_spec1 {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
 
   }
   Variable var_wo_typ {
       spec_category = '10us';
   }
+}
 
-  Variable var_w_spec {
-      spec_category {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
-      spec_category1 {Min '1ms'; Typ '1.5ms'; Max '12ms' ;}
+Spec { 
+  Category category_wo_spec_domain {
+
+      nd_catvar_wo_typ = '1us';
+
+  }
+  Variable nd_var_wo_typ {
+      category_wo_spec_domain = '10us';
   }
 }
 
-
-Selector typSelector {
-        catvar_w_spec Typ;
-        var_w_spec Typ;
-}
-
-Selector maxSelector {
-        catvar_w_spec1 Max;
-        spec_category1 Max;
-}
 
 PatternBurst patt_burst{
     PatList { pattern;
@@ -107,9 +101,8 @@ PatternBurst patt_burst{
 }
 
 PatternExec {
-    Selector typSelector;
-    Selector maxSelector;
     Category spec_category;
+    Category category_wo_spec_domain;
     PatternBurst patt_burst;
 }
 

--- a/tests/test_spec_block.py
+++ b/tests/test_spec_block.py
@@ -217,3 +217,13 @@ def test_issue_55():
     parser.parse_semantic()
     assert parser.err_line == -1
     assert parser.err_col == -1
+
+def test_issue_60():
+
+    stil_file = get_stil_file("test_issue_60.stil")
+
+    parser = STILParser(stil_file)
+    parser.parse_syntax()
+    parser.parse_semantic()
+    assert parser.err_line == -1
+    assert parser.err_col == -1


### PR DESCRIPTION
The following changes have been made:
- Allow variables with value only (Typ) to be used without selector.
- Removed requirement to have Selector block if variables are used. In this case we expect all variables to have value (Typ).
- Added possibility to have more than one (Category)* and (Selector)* in the PatternExec block according the standard.